### PR TITLE
Adjust Readme, adjust projects to allow nuget generation with .NET 5 and insert some event properties on default data

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,28 +12,28 @@ The Seq.App.Azure.EventHub app can be used to send Seq events to an Azure Event 
 ## Stream Analytics and Power BI
 The following section walks you through setting up Stream Analytics with a Event Hub input and a Power BI output.
 
-##1. Create a Service Bus
+## 1. Create a Service Bus
 If you don't already have one, you'll need to create an Azure Service bus to house the Event Hub.
 
 ![Create Service Bus](docs/images/create_service_bus.png)
 
-##2. Event Hub
-###2a. Create Event Hub
+## 2. Event Hub
+### 2a. Create Event Hub
 Now you can create your Event Hub.  Name it whatever you like and is available.  It should be something meaningful to your project/application.
 
 ![Create Event Hub](docs/images/create_event_hub.png)
 
-###2b. Configure a Shared Access Policy
+### 2b. Configure a Shared Access Policy
 Once the Event Hub is created, go over to the Configure tab and create a Share Access Policy.  This allows you to generate a connection string and send events to the hub.  You'll just need Send permissions.
 
 ![Configure Shared Access Policy](docs/images/configure_shared_access_policy.png)
 
-###2c. Connection String
+### 2c. Connection String
 Now go back to the Event Hub Dashboard and get the connection string by clicking View Connection String then copy it to your clipboard.
 
 ![Event Hub Connection String](docs/images/event_hub_connection_string.png)
 
-##3. Configure Seq App
+## 3. Configure Seq App
 Next you'll need to configure the EventHub app in Seq.  Go to Settings->Apps and click Start New Instance under Azure Event Hub and set the properties similar to the following:
 
 ![Configure Seq App](docs/images/configure_seq_app.png)
@@ -42,13 +42,13 @@ Once created, go back into the app instance and click the View events raised by 
 
 ![Verify Seq App](docs/images/verify_app.png)
 
-##4. Stream Analytics
-###4a. Create Job
+## 4. Stream Analytics
+### 4a. Create Job
 Now that you've verified that Seq is sending events to your Event Hub it's time to create a Stream Analytics job.
 
 ![Create Stream Analytics Job](docs/images/create_stream_analytics_job.png)
 
-###4b. Add Input
+### 4b. Add Input
 Create an input for the Stream Analytics job.  The input will be the Event Hub you just created and are now sending Seq events to.
 
 ![Add Input - Step 1](docs/images/add_input_job_1.png)
@@ -59,7 +59,7 @@ Create an input for the Stream Analytics job.  The input will be the Event Hub y
 
 ![Add Input - Step 4](docs/images/add_input_job_4.png)
 
-###4c. Add Output
+### 4c. Add Output
 Add an output.  For this example you'll create a Power BI output like so:
 
 ![Add Output - Step 1](docs/images/add_output_1.png)
@@ -68,13 +68,13 @@ Add an output.  For this example you'll create a Power BI output like so:
 
 ![Add Output - Step 3](docs/images/add_output_3.png)
 
-###4d. Create Query
+### 4d. Create Query
 Finally, create a Stream Analytics query to transfer data from the event hub to the Power BI output.
 
 ![Create Query](docs/images/create_query.png)
 
-##5. Power BI
-###5a. Dataset
+## 5. Power BI
+### 5a. Dataset
 Once Stream Analytics starts sending data to Power BI, the dataset will be automatically created for you as you can see below:
 
 ![Dataset](docs/images/pbi_dataset.png)
@@ -87,7 +87,7 @@ Click the thumbtack to save the report and pin it to your dashboard:
 
 ![Pin to Dashboard](docs/images/pbi_pin_to_dashboard.png)
 
-###5b. Dashboard
+### 5b. Dashboard
 Now you can view your report on the dashboard!
 
 ![Dashboard](docs/images/pbi_dashboard.png)

--- a/Seq.App.Azure.EventHub/EventHubReactor.cs
+++ b/Seq.App.Azure.EventHub/EventHubReactor.cs
@@ -313,6 +313,9 @@ namespace Seq.App.Azure.EventHub
                 // Add the Event type to all messages
                 propertyData.Add("EventType", evt.EventType);
 
+                // Add the Level to all messages
+                propertyData.Add("Level", evt.Data.Level);
+
                 if (_splitPropertyDataTypes != null)
                 {
                     // Add special suffix to indicate we have a forced data type

--- a/Seq.App.Azure.EventHub/EventHubReactor.cs
+++ b/Seq.App.Azure.EventHub/EventHubReactor.cs
@@ -173,6 +173,20 @@ namespace Seq.App.Azure.EventHub
             }
         }
 
+        [SeqAppSetting(
+            DisplayName = "Insert rendered message",
+            HelpText = "If checked, will insert rendered message on output",
+            IsOptional = true)]
+
+        public bool InsertRenderedMessage { get; set; }
+
+        [SeqAppSetting(
+            DisplayName = "Insert message template",
+            HelpText = "If checked, will insert message template on output",
+            IsOptional = true)]
+
+        public bool InsertMessageTemplate { get; set; }
+
         private static Lazy<EventHubProducerClient> _lazyClient;
 
         private static EventHubProducerClient Client
@@ -296,6 +310,9 @@ namespace Seq.App.Azure.EventHub
                 // Add a Timestamp to all messages
                 propertyData.Add("Timestamp", evt.TimestampUtc);
 
+                // Add the Event type to all messages
+                propertyData.Add("EventType", evt.EventType);
+
                 if (_splitPropertyDataTypes != null)
                 {
                     // Add special suffix to indicate we have a forced data type
@@ -316,6 +333,12 @@ namespace Seq.App.Azure.EventHub
                     }
                     propertyData = outData;
                 }
+
+                if (InsertRenderedMessage)
+                    propertyData.Add("RenderedMessage", evt.Data.RenderedMessage);
+
+                if (InsertMessageTemplate)
+                    propertyData.Add("MessageTemplate", evt.Data.MessageTemplate);
 
                 var message = JsonConvert.SerializeObject(propertyData);
 

--- a/Seq.App.Azure.EventHub/Seq.App.Azure.EventHub.csproj
+++ b/Seq.App.Azure.EventHub/Seq.App.Azure.EventHub.csproj
@@ -1,46 +1,67 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
 
-	<PropertyGroup>
-		<TargetFramework>net5.0</TargetFramework>
-		<Copyright>(C) Copyright 2016 Michael Kaltner</Copyright>
-		<PackageTags>seq-app;seq;serilog;event azure;event hub</PackageTags>
-		<PackageReleaseNotes>
-			1.1.0 - Upgrade to .NET 5
-			1.0.15 - Remove field that has the same name as a static property
-			1.0.14 - Remove fields that are configured as tags
-			1.0.13 - Fixed another issue with tags
-			1.0.12 - Fixed issue with tags
-			1.0.11 - Force tags to be tags
-			1.0.10 - Allow exclude/ignore properties from the data type specification
-			1.0.9 - Added a way to force the data type for properties
-			1.0.8 - Added trigger processing and updated dependencies
-			1.0.7 - Added batching of messages and tag properties
-			1.0.6 - Performance optimizations
-			1.0.5 - Upgraded to Serilog 2.2.1
-		</PackageReleaseNotes>
-		<PackageLicenseExpression>MIT</PackageLicenseExpression>
-		<GeneratePackageOnBuild>True</GeneratePackageOnBuild>
-		<Version>$(VersionPrefix)</Version>
-		<PackageProjectUrl>https://github.com/mkaltner/Seq.App.Azure</PackageProjectUrl>
-		<PackageReadmeFile>README.md</PackageReadmeFile>
-		<VersionPrefix>1.1.0</VersionPrefix>
-	</PropertyGroup>
+  <PropertyGroup>
+    <TargetFramework>net5.0</TargetFramework>
+    <Copyright>(C) Copyright 2016 Michael Kaltner</Copyright>
+    <PackageTags>seq-app;seq;serilog;event azure;event hub</PackageTags>
+    <PackageReleaseNotes>
+      1.1.0 - Upgrade to .NET 5
+      1.0.15 - Remove field that has the same name as a static property
+      1.0.14 - Remove fields that are configured as tags
+      1.0.13 - Fixed another issue with tags
+      1.0.12 - Fixed issue with tags
+      1.0.11 - Force tags to be tags
+      1.0.10 - Allow exclude/ignore properties from the data type specification
+      1.0.9 - Added a way to force the data type for properties
+      1.0.8 - Added trigger processing and updated dependencies
+      1.0.7 - Added batching of messages and tag properties
+      1.0.6 - Performance optimizations
+      1.0.5 - Upgraded to Serilog 2.2.1
+    </PackageReleaseNotes>
+    <PackageLicenseExpression>MIT</PackageLicenseExpression>
+    <GeneratePackageOnBuild>True</GeneratePackageOnBuild>
+    <Version>$(VersionPrefix)</Version>
+    <PackageProjectUrl>https://github.com/mkaltner/Seq.App.Azure</PackageProjectUrl>
+    <PackageReadmeFile>README.md</PackageReadmeFile>
+    <VersionPrefix>1.1.0</VersionPrefix>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
+  </PropertyGroup>
 
-	<ItemGroup>
-		<None Include="..\README.md">
-			<Pack>True</Pack>
-			<PackagePath>\</PackagePath>
-		</None>
-	</ItemGroup>
+  <ItemGroup>
+    <None Include="..\README.md">
+      <Pack>True</Pack>
+      <PackagePath>\</PackagePath>
+    </None>
+  </ItemGroup>
 
-	<ItemGroup>
-		<PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.0" />
-		<PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
-		<PackageReference Include="System.Reactive" Version="5.0.0" />
-	</ItemGroup>
+  <ItemGroup>
+    <PackageReference Include="Azure.Messaging.EventHubs" Version="5.7.0" />
+    <PackageReference Include="Newtonsoft.Json" Version="13.0.1" />
+    <PackageReference Include="System.Reactive" Version="5.0.0" />
+  </ItemGroup>
 
-	<ItemGroup>
-		<ProjectReference Include="..\Seq.App.Azure\Seq.App.Azure.csproj" />
-	</ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Seq.App.Azure\Seq.App.Azure.csproj" PrivateAssets="All" />
+  </ItemGroup>
 
+  <PropertyGroup>
+    <TargetsForTfmSpecificBuildOutput>$(TargetsForTfmSpecificBuildOutput);CopyReferencesToPackage</TargetsForTfmSpecificBuildOutput>
+  </PropertyGroup>
+
+  <Target Name="CopyReferencesToPackage" DependsOnTargets="BuildOnlySettings;ResolveReferences">
+    <ItemGroup>
+      <!--Filter out unnecessary files-->
+      <!--<_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths->WithMetadataValue('ReferenceSourceTarget', 'ProjectReference')->WithMetadataValue('PrivateAssets', 'All'))"/>-->
+      <_ReferenceCopyLocalPaths Include="@(ReferenceCopyLocalPaths)"/>
+    </ItemGroup>
+
+    <!-- Print batches for debug purposes -->
+    <Message Text="Batch for .nupkg: ReferenceCopyLocalPaths = @(_ReferenceCopyLocalPaths), ReferenceCopyLocalPaths.DestinationSubDirectory = %(_ReferenceCopyLocalPaths.DestinationSubDirectory) Filename = %(_ReferenceCopyLocalPaths.Filename) Extension = %(_ReferenceCopyLocalPaths.Extension)" Importance="High" Condition="'@(_ReferenceCopyLocalPaths)' != ''" />
+
+    <ItemGroup>
+      <!-- Add file to package with consideration of sub folder. If empty, the root folder is chosen. -->
+      <BuildOutputInPackage Include="@(_ReferenceCopyLocalPaths)" TargetPath="%(_ReferenceCopyLocalPaths.DestinationSubDirectory)"/>
+    </ItemGroup>
+  </Target>
 </Project>

--- a/Seq.App.Azure/Seq.App.Azure.csproj
+++ b/Seq.App.Azure/Seq.App.Azure.csproj
@@ -2,6 +2,8 @@
 
   <PropertyGroup>
     <TargetFramework>net5.0</TargetFramework>
+    <RestoreProjectStyle>PackageReference</RestoreProjectStyle>
+    <CopyLocalLockFileAssemblies>true</CopyLocalLockFileAssemblies>
   </PropertyGroup>
 
   <ItemGroup>


### PR DESCRIPTION
- Adjust README format
- Adjust projects to allow nuget generation
  - Based on [Seq Documentation](https://docs.datalust.co/docs/writing-seq-apps) we need to insert the other libraries on the packages because Seq will not restore other packages.
- Insert some properties on default properties data
  - Level
  - EventType
- Create optional properties to allow save the template message and rendered message   